### PR TITLE
Make Java annotation processor bw/fw compatible

### DIFF
--- a/grooves-java/src/main/java/com/github/rahulsom/grooves/java/QueryProcessor.java
+++ b/grooves-java/src/main/java/com/github/rahulsom/grooves/java/QueryProcessor.java
@@ -16,7 +16,6 @@ import static javax.tools.Diagnostic.Kind.ERROR;
         QueryProcessor.EVENT_ANNOTATION,
         QueryProcessor.QUERY_ANNOTATION,
 })
-@SupportedSourceVersion(SourceVersion.RELEASE_10)
 @AutoService(Processor.class)
 public class QueryProcessor extends AbstractProcessor {
 
@@ -149,4 +148,8 @@ public class QueryProcessor extends AbstractProcessor {
         }
     }
 
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
 }


### PR DESCRIPTION
The SupportedSourceVersion annotation is not required.
Having it in, makes the jar version specific.
Without it, we can support 8 through 10.
May be even 11.