### PR TITLE
Update gradle wrapper to 5.5.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The Gradle team is excited to announce Gradle 5.5.

[Read the release notes](https://docs.gradle.org/5.5/release-notes.html)

We would like to thank the following community contributors to this release of Gradle:
[Martin d'Anjou](https://github.com/martinda),
[Ben Asher](https://github.com/benasher44),
[Mike Kobit](https://github.com/mkobit),
[Erhard Pointl](https://github.com/epeee),
[Sebastian Schuberth](https://github.com/sschuberth),
[Evgeny Mandrikov](https://github.com/Godin),
[Stefan M.](https://github.com/StefMa),
[Igor Melnichenko](https://github.com/igor-melnichenko),
[Björn Kautler](https://github.com/Vampire),
[Roberto Perez Alcolea](https://github.com/rpalcolea) and
[Christian Fränkel](https://github.com/fraenkelc).

## Upgrade Instructions

Switch your build to use Gradle 5.5 by updating your wrapper properties:

`./gradlew wrapper --gradle-version=5.5`

Standalone downloads are available at [gradle.org/releases](https://gradle.org/releases).

## Reporting Problems

If you find a problem with Gradle, please file a bug on [GitHub Issues](https://github.com/gradle/gradle/issues) adhering to our issue guidelines. If you're not sure you're encountering a bug, please use the [forum](https://discuss.gradle.org/c/help-discuss).