### PR TITLE
Add kotlin implementation without reactive-streams

### DIFF
--- a/grooves-core/build.gradle
+++ b/grooves-core/build.gradle
@@ -1,0 +1,59 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("dev.jacomet.logging-capabilities") version "0.+"
+    id("io.freefair.aspectj.post-compile-weaving") version "6.3.0"
+    id('java-library')
+
+}
+
+loggingCapabilities {
+    enforceLogback("testRuntimeClasspath")
+}
+
+dependencies {
+    // configureLombok()
+    compileOnly("org.projectlombok:lombok:1.18.22")
+    testCompileOnly("org.projectlombok:lombok:1.18.22")
+    annotationProcessor("org.projectlombok:lombok:1.18.22")
+    testAnnotationProcessor("org.projectlombok:lombok:1.18.22")
+
+    // configureKotlin()
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+
+    // configureJUnit()
+    implementation(platform("org.junit:junit-bom:5.+"))
+    testImplementation("org.assertj:assertj-core:3.11.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+
+    //configureLogging()
+    implementation("org.slf4j:slf4j-api:1.7.32")
+    testRuntimeOnly("org.slf4j:slf4j-simple:1.7.32")
+    testRuntimeOnly("org.apache.logging.log4j:log4j-core:2.7")
+    testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.7")
+    testRuntimeOnly("ch.qos.logback:logback-classic:0.9.26")
+
+    implementation("org.aspectj:aspectjrt:1.9.7")
+}
+
+tasks.withType(KotlinCompile) {
+    kotlinOptions {
+        jvmTarget = "1.8"
+        freeCompilerArgs = ["-Xjvm-default=all", "-Xinline-classes"]
+    }
+}
+
+tasks.withType(Test) {
+    useJUnitPlatform()
+
+    // Configure Slf4j Simple Logger
+    systemProperty("org.slf4j.simpleLogger.log.com.github.rahulsom.grooves", "DEBUG")
+}
+
+
+

--- a/grooves-core/src/main/java/com/github/rahulsom/grooves/GroovesQueryBuilder.java
+++ b/grooves-core/src/main/java/com/github/rahulsom/grooves/GroovesQueryBuilder.java
@@ -1,0 +1,82 @@
+package com.github.rahulsom.grooves;
+
+import com.github.rahulsom.grooves.functions.*;
+import com.github.rahulsom.grooves.impl.GroovesQueryImpl;
+import lombok.Builder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds a {@link GroovesQuery}.
+ *
+ * @param <AggregateT>          The type of the Aggregate
+ * @param <VersionOrTimestampT> The type of the fields that denotes version or timestamp
+ * @param <SnapshotT>           The type of the Snapshot being computed
+ * @param <EventT>              The type of the Event
+ */
+@Builder
+public class GroovesQueryBuilder<AggregateT, VersionOrTimestampT, SnapshotT, EventT, EventIdT> {
+
+    private SnapshotProvider<AggregateT, VersionOrTimestampT, SnapshotT> snapshotProvider;
+    private EmptySnapshotProvider<AggregateT, SnapshotT> emptySnapshotProvider;
+    private EventsProvider<AggregateT, VersionOrTimestampT, SnapshotT, EventT> eventsProvider;
+    private ApplyMoreEventsPredicate<SnapshotT> applyMoreEventsPredicate;
+    private Deprecator<SnapshotT, EventT> deprecator;
+    private ExceptionHandler<SnapshotT, EventT> exceptionHandler;
+    private EventHandler<EventT, SnapshotT> eventHandler;
+    private EventClassifier<EventT> eventClassifier;
+    private EventVersioner<EventT, VersionOrTimestampT> eventVersionProvider;
+    private SnapshotVersioner<SnapshotT, VersionOrTimestampT> snapshotVersionSetter;
+    private DeprecatedByProvider<EventT, AggregateT, EventIdT> deprecatedByProvider;
+    private RevertedEventProvider<EventT> revertedEventProvider;
+    private EventIdProvider<EventT, EventIdT> eventIdProvider;
+
+    GroovesQuery<AggregateT, VersionOrTimestampT, SnapshotT, EventT, EventIdT> toQuery() {
+        ArrayList<String> exceptions = new ArrayList<>();
+        checkNotNull(exceptions, snapshotProvider, "snapshotProvider is not set");
+        checkNotNull(exceptions, emptySnapshotProvider, "emptySnapshotProvider is not set");
+        checkNotNull(exceptions, eventsProvider, "eventsProvider is not set");
+        checkNotNull(exceptions, exceptionHandler, "exceptionHandler is not set");
+        checkNotNull(exceptions, eventHandler, "eventHandler is not set");
+        checkNotNull(exceptions, eventClassifier, "eventClassifier is not set");
+        checkNotNull(exceptions, applyMoreEventsPredicate, "applyMoreEventsPredicate is not set");
+        checkNotNull(exceptions, deprecator, "deprecator is not set");
+        checkNotNull(exceptions, eventVersionProvider, "eventVersionProvider is not set");
+        checkNotNull(exceptions, snapshotVersionSetter, "snapshotVersionSetter is not set");
+        checkNotNull(exceptions, deprecatedByProvider, "deprecatedByProvider is not set");
+        checkNotNull(exceptions, revertedEventProvider, "revertedEventProvider is not set");
+        checkNotNull(exceptions, eventIdProvider, "eventIdProvider is not set");
+
+        if (exceptions.isEmpty()) {
+            return new GroovesQueryImpl<>(
+                snapshotProvider,
+                emptySnapshotProvider,
+                eventsProvider,
+                applyMoreEventsPredicate,
+                eventClassifier,
+                deprecator,
+                exceptionHandler,
+                eventHandler,
+                eventVersionProvider,
+                snapshotVersionSetter,
+                deprecatedByProvider,
+                revertedEventProvider,
+                eventIdProvider
+            );
+        } else {
+            String firstException = exceptions.remove(0);
+            IllegalStateException illegalStateException = new IllegalStateException(firstException);
+            exceptions.stream().map(IllegalStateException::new)
+                .forEach(illegalStateException::addSuppressed);
+
+            throw illegalStateException;
+        }
+    }
+
+    private void checkNotNull(List<String> exceptions, Object function, String message) {
+        if (function == null) {
+            exceptions.add(message);
+        }
+    }
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/DeprecatedByResult.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/DeprecatedByResult.kt
@@ -1,0 +1,3 @@
+package com.github.rahulsom.grooves
+
+data class DeprecatedByResult<Aggregate, EventId>(val aggregate: Aggregate, val eventId: EventId)

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/EventApplyOutcome.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/EventApplyOutcome.kt
@@ -1,0 +1,8 @@
+package com.github.rahulsom.grooves
+
+/**
+ * The outcome of applying an event to a snapshot.
+ */
+enum class EventApplyOutcome {
+    RETURN, CONTINUE
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/EventType.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/EventType.kt
@@ -1,0 +1,5 @@
+package com.github.rahulsom.grooves
+
+enum class EventType {
+    Normal, Revert, Deprecates, DeprecatedBy
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/GroovesQuery.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/GroovesQuery.kt
@@ -1,0 +1,12 @@
+package com.github.rahulsom.grooves
+
+interface GroovesQuery<Aggregate, VersionOrTimestamp, Snapshot, Event, EventId> {
+    fun computeSnapshot(aggregate: Aggregate, at: VersionOrTimestamp?, redirect: Boolean):
+        GroovesResult<Snapshot, Aggregate, VersionOrTimestamp>
+
+    fun computeSnapshot(aggregate: Aggregate, at: VersionOrTimestamp?) =
+        (
+            computeSnapshot(aggregate, at, true)
+                as GroovesResult.Success<Snapshot, Aggregate, VersionOrTimestamp>
+            ).snapshot
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/GroovesResult.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/GroovesResult.kt
@@ -1,0 +1,9 @@
+package com.github.rahulsom.grooves
+
+sealed class GroovesResult<Snapshot, Aggregate, VersionOrTimestamp> {
+    data class Success<Snapshot, Aggregate, VersionOrTimestamp>(val snapshot: Snapshot) :
+        GroovesResult<Snapshot, Aggregate, VersionOrTimestamp>()
+
+    data class Redirect<Snapshot, Aggregate, VersionOrTimestamp>(val aggregate: Aggregate, val at: VersionOrTimestamp) :
+        GroovesResult<Snapshot, Aggregate, VersionOrTimestamp>()
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/ApplyMoreEventsPredicate.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/ApplyMoreEventsPredicate.kt
@@ -1,0 +1,12 @@
+package com.github.rahulsom.grooves.functions
+
+import com.github.rahulsom.grooves.logging.Trace
+
+/**
+ * A predicate that decides whether to apply more events to the snapshot.
+ * Some conditions may require that the snapshot is not updated and returned as is.
+ */
+interface ApplyMoreEventsPredicate<Snapshot> {
+    @Trace(false)
+    fun invoke(snapshot: Snapshot): Boolean
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/DeprecatedByProvider.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/DeprecatedByProvider.kt
@@ -1,0 +1,12 @@
+package com.github.rahulsom.grooves.functions
+
+import com.github.rahulsom.grooves.DeprecatedByResult
+import com.github.rahulsom.grooves.logging.Trace
+
+/**
+ * Identifies the Aggregate that is deprecated by the given event, and the event id that's the converse of the given event.
+ */
+interface DeprecatedByProvider<Event, Aggregate, EventId> {
+    @Trace(false)
+    fun invoke(event: Event): DeprecatedByResult<Aggregate, EventId>
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/Deprecator.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/Deprecator.kt
@@ -1,0 +1,11 @@
+package com.github.rahulsom.grooves.functions
+
+import com.github.rahulsom.grooves.logging.Trace
+
+/**
+ * Stores information in a snapshot about an aggregate that is deprecated by it.
+ */
+interface Deprecator<Snapshot, Aggregate> {
+    @Trace(false)
+    fun invoke(snapshot: Snapshot, deprecatingAggregate: Aggregate)
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/EmptySnapshotProvider.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/EmptySnapshotProvider.kt
@@ -1,0 +1,12 @@
+package com.github.rahulsom.grooves.functions
+
+import com.github.rahulsom.grooves.logging.Trace
+
+/**
+ * A snapshot provider that always returns an empty snapshot.
+ * This can be used to build a snapshot with additional events.
+ */
+interface EmptySnapshotProvider<Aggregate, Snapshot> {
+    @Trace(false)
+    fun invoke(aggregate: Aggregate): Snapshot
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/EventClassifier.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/EventClassifier.kt
@@ -1,0 +1,12 @@
+package com.github.rahulsom.grooves.functions
+
+import com.github.rahulsom.grooves.EventType
+import com.github.rahulsom.grooves.logging.Trace
+
+/**
+ * Classifies the type of event.
+ */
+interface EventClassifier<Event> {
+    @Trace(false)
+    fun invoke(event: Event): EventType
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/EventHandler.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/EventHandler.kt
@@ -1,0 +1,12 @@
+package com.github.rahulsom.grooves.functions
+
+import com.github.rahulsom.grooves.EventApplyOutcome
+import com.github.rahulsom.grooves.logging.Trace
+
+/**
+ * Applies the event to a snapshot.
+ */
+interface EventHandler<Event, Snapshot> {
+    @Trace(false)
+    fun invoke(event: Event, snapshot: Snapshot): EventApplyOutcome
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/EventIdProvider.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/EventIdProvider.kt
@@ -1,0 +1,8 @@
+package com.github.rahulsom.grooves.functions
+
+/**
+ * A function that returns an event id for a given event.
+ */
+interface EventIdProvider<Event, EventId> {
+    fun invoke(event: Event): EventId
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/EventVersioner.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/EventVersioner.kt
@@ -1,0 +1,11 @@
+package com.github.rahulsom.grooves.functions
+
+import com.github.rahulsom.grooves.logging.Trace
+
+/**
+ * Provides the version of the event.
+ */
+interface EventVersioner<Event, VersionOrTimestamp> {
+    @Trace(false)
+    fun invoke(event: Event): VersionOrTimestamp
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/EventsProvider.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/EventsProvider.kt
@@ -1,0 +1,17 @@
+package com.github.rahulsom.grooves.functions
+
+import com.github.rahulsom.grooves.logging.Trace
+import java.util.stream.Stream
+
+/**
+ * Provides events that are later than the last known snapshot up until the version specified.
+ * If the version specified is null, then all events are returned.
+ */
+interface EventsProvider<Aggregate, VersionOrTimestamp, Snapshot, Event> {
+    @Trace(false)
+    fun invoke(
+        aggregates: List<Aggregate>,
+        versionOrTimestamp: VersionOrTimestamp?,
+        lastSnapshot: Snapshot
+    ): Stream<Event>
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/ExceptionHandler.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/ExceptionHandler.kt
@@ -1,0 +1,12 @@
+package com.github.rahulsom.grooves.functions
+
+import com.github.rahulsom.grooves.EventApplyOutcome
+import com.github.rahulsom.grooves.logging.Trace
+
+/**
+ * A function that handles exceptions thrown when applying an event to a snapshot.
+ */
+interface ExceptionHandler<Snapshot, Event> {
+    @Trace(false)
+    fun invoke(exception: Exception, snapshot: Snapshot, event: Event): EventApplyOutcome
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/RevertedEventProvider.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/RevertedEventProvider.kt
@@ -1,0 +1,11 @@
+package com.github.rahulsom.grooves.functions
+
+import com.github.rahulsom.grooves.logging.Trace
+
+/**
+ * Given a revert event, provides the event that is reverted by it.
+ */
+interface RevertedEventProvider<Event> {
+    @Trace(false)
+    fun invoke(event: Event): Event
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/SnapshotProvider.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/SnapshotProvider.kt
@@ -1,0 +1,11 @@
+package com.github.rahulsom.grooves.functions
+
+import com.github.rahulsom.grooves.logging.Trace
+
+/**
+ * Finds a snapshot for a given aggregate that is at most as recent as the given version.
+ */
+interface SnapshotProvider<Aggregate, VersionOrTimestamp, Snapshot> {
+    @Trace(false)
+    fun invoke(aggregate: Aggregate, versionOrTimestamp: VersionOrTimestamp?): Snapshot?
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/SnapshotVersioner.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/functions/SnapshotVersioner.kt
@@ -1,0 +1,11 @@
+package com.github.rahulsom.grooves.functions
+
+import com.github.rahulsom.grooves.logging.Trace
+
+/**
+ * Sets the version of the snapshot to the given version.
+ */
+interface SnapshotVersioner<Snapshot, VersionOrTimestamp> {
+    @Trace(false)
+    fun invoke(snapshot: Snapshot, versionOrTimestamp: VersionOrTimestamp)
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/impl/GroovesQueryImpl.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/impl/GroovesQueryImpl.kt
@@ -1,0 +1,184 @@
+package com.github.rahulsom.grooves.impl
+
+import com.github.rahulsom.grooves.EventApplyOutcome
+import com.github.rahulsom.grooves.EventApplyOutcome.RETURN
+import com.github.rahulsom.grooves.EventType.DeprecatedBy
+import com.github.rahulsom.grooves.EventType.Deprecates
+import com.github.rahulsom.grooves.EventType.Normal
+import com.github.rahulsom.grooves.EventType.Revert
+import com.github.rahulsom.grooves.GroovesQuery
+import com.github.rahulsom.grooves.GroovesResult
+import com.github.rahulsom.grooves.functions.ApplyMoreEventsPredicate
+import com.github.rahulsom.grooves.functions.DeprecatedByProvider
+import com.github.rahulsom.grooves.functions.Deprecator
+import com.github.rahulsom.grooves.functions.EmptySnapshotProvider
+import com.github.rahulsom.grooves.functions.EventClassifier
+import com.github.rahulsom.grooves.functions.EventHandler
+import com.github.rahulsom.grooves.functions.EventIdProvider
+import com.github.rahulsom.grooves.functions.EventVersioner
+import com.github.rahulsom.grooves.functions.EventsProvider
+import com.github.rahulsom.grooves.functions.ExceptionHandler
+import com.github.rahulsom.grooves.functions.RevertedEventProvider
+import com.github.rahulsom.grooves.functions.SnapshotProvider
+import com.github.rahulsom.grooves.functions.SnapshotVersioner
+import com.github.rahulsom.grooves.logging.IndentedLogging
+import com.github.rahulsom.grooves.logging.Trace
+import org.slf4j.LoggerFactory
+import java.util.stream.Collectors
+
+class GroovesQueryImpl<VersionOrTimestamp, Snapshot, Aggregate, Event, EventId>(
+    private val snapshotProvider: SnapshotProvider<Aggregate, VersionOrTimestamp, Snapshot>,
+    private val emptySnapshotProvider: EmptySnapshotProvider<Aggregate, Snapshot>,
+    private val eventsProvider: EventsProvider<Aggregate, VersionOrTimestamp, Snapshot, Event>,
+    private val applyMoreEventsPredicate: ApplyMoreEventsPredicate<Snapshot>,
+    private val eventClassifier: EventClassifier<Event>,
+    private val deprecator: Deprecator<Snapshot, Event>,
+    private val exceptionHandler: ExceptionHandler<Snapshot, Event>,
+    private val eventHandler: EventHandler<Event, Snapshot>,
+    private val eventVersioner: EventVersioner<Event, VersionOrTimestamp>,
+    private val snapshotVersioner: SnapshotVersioner<Snapshot, VersionOrTimestamp>,
+    private val deprecatedByProvider: DeprecatedByProvider<Event, Aggregate, EventId>,
+    private val revertedEventProvider: RevertedEventProvider<Event>,
+    private val eventIdProvider: EventIdProvider<Event, EventId>
+) : GroovesQuery<Aggregate, VersionOrTimestamp, Snapshot, Event, EventId> {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Trace(true)
+    override fun computeSnapshot(aggregate: Aggregate, at: VersionOrTimestamp?, redirect: Boolean): GroovesResult<Snapshot, Aggregate, VersionOrTimestamp> {
+        val providedSnapshot = snapshotProvider.invoke(aggregate, at)
+        val snapshot = providedSnapshot ?: emptySnapshotProvider.invoke(aggregate)
+        val events = eventsProvider.invoke(listOf(aggregate), at, snapshot).collect(Collectors.toList())
+
+        return computeSnapshotImpl(events, snapshot, listOf(aggregate), at, redirect) { c, s ->
+            if (s != null) {
+                log.trace("${c.data} -> $s")
+            }
+            IndentedLogging.stepOut()
+        }
+    }
+
+    // @JvmInline
+    private inline class CallIdentifier(val data: String)
+
+    private tailrec fun computeSnapshotImpl(
+        events: List<Event>,
+        snapshot: Snapshot,
+        aggregates: List<Aggregate>,
+        at: VersionOrTimestamp?,
+        redirect: Boolean,
+        beforeReturn: (CallIdentifier, Snapshot?) -> Unit
+    ): GroovesResult<Snapshot, Aggregate, VersionOrTimestamp> {
+        val indent = IndentedLogging.indentString()
+
+        val callIdentifier = CallIdentifier("${indent}computeSnapshotImpl(<... ${events.size} items>, $snapshot, $aggregates, $at)")
+        log.trace(callIdentifier.data)
+        IndentedLogging.stepIn()
+        val (revertEvents, forwardEvents) = events
+            .partition { eventClassifier.invoke(it) == Revert }
+            .let { it.first.toMutableList() to it.second.toMutableList() }
+
+        if (revertsExistOutsideEvents(revertEvents, indent, forwardEvents)) {
+            val snapshot1 = emptySnapshotProvider.invoke(aggregates[0])
+            val events1 = eventsProvider.invoke(aggregates, at, snapshot1).collect(Collectors.toList())
+            return computeSnapshotImpl(events1, snapshot1, aggregates, at, redirect) { c, s ->
+                beforeReturn(c, s)
+                IndentedLogging.stepOut()
+            }
+        }
+
+        val deprecatesEvents = forwardEvents.filter { eventClassifier.invoke(it) == Deprecates }.toMutableList()
+        while (deprecatesEvents.isNotEmpty()) {
+            val event = deprecatesEvents.removeAt(0)
+            val converseId = deprecatedByProvider.invoke(event).eventId
+            deprecator.invoke(snapshot, event)
+            forwardEvents.remove(event)
+            forwardEvents.removeIf { eventIdProvider.invoke(it) == converseId }
+        }
+
+        for (event in forwardEvents) {
+            if (applyMoreEventsPredicate.invoke(snapshot)) {
+                val outcome: EventApplyOutcome =
+                    when (eventClassifier.invoke(event)) {
+                        Normal -> tryRunning(snapshot, event) { eventHandler.invoke(event, snapshot) }
+                        Deprecates -> {
+                            beforeReturn(callIdentifier, null)
+                            throw IllegalStateException("Shouldn't have found Deprecates event here - $event")
+                        }
+                        DeprecatedBy -> {
+                            val ret = deprecatedByProvider.invoke(event)
+                            log.debug("$indent  ...The aggregate was deprecated by ${ret.aggregate}. Recursing to compute snapshot for it...")
+                            val refEvent = eventsProvider.invoke(listOf(ret.aggregate), null, emptySnapshotProvider.invoke(ret.aggregate))
+                                .collect(Collectors.toList())
+                                .find { eventIdProvider.invoke(it) == ret.eventId }
+
+                            val redirectVersion = eventVersioner.invoke(refEvent!!)
+                            val otherSnapshot = snapshotProvider.invoke(ret.aggregate, redirectVersion) ?: emptySnapshotProvider.invoke(ret.aggregate)
+                            val newEvents = eventsProvider.invoke(listOf(ret.aggregate) + aggregates, redirectVersion, otherSnapshot)
+                                .collect(Collectors.toList())
+                            @Suppress("LiftReturnOrAssignment")
+                            if (redirect) {
+                                return computeSnapshotImpl(newEvents, otherSnapshot, aggregates + listOf(ret.aggregate), at, redirect) { c, s ->
+                                    beforeReturn(c, s)
+                                    IndentedLogging.stepOut()
+                                }
+                            } else {
+                                return GroovesResult.Redirect(ret.aggregate, redirectVersion)
+                            }
+                        }
+                        Revert -> {
+                            beforeReturn(callIdentifier, null)
+                            throw IllegalStateException("Shouldn't have found Revert event here - $event")
+                        }
+                    }
+
+                val versionOrTimestamp = eventVersioner.invoke(event)
+                snapshotVersioner.invoke(snapshot, versionOrTimestamp)
+
+                if (outcome == RETURN) {
+                    log.debug("$indent  ...Event apply outcome was RETURN. Returning snapshot...")
+                    beforeReturn(callIdentifier, snapshot)
+                    return GroovesResult.Success(snapshot)
+                }
+            }
+        }
+
+        val versionOrTimestamp = eventVersioner.invoke(events.last())
+        snapshotVersioner.invoke(snapshot, versionOrTimestamp)
+
+        beforeReturn(callIdentifier, snapshot)
+        return GroovesResult.Success(snapshot)
+    }
+
+    private fun revertsExistOutsideEvents(
+        revertEvents: MutableList<Event>,
+        indent: String,
+        forwardEvents: MutableList<Event>
+    ): Boolean {
+        while (revertEvents.isNotEmpty()) {
+            val mostRecentRevert = revertEvents.removeLast()
+            val revertedEvent = revertedEventProvider.invoke(mostRecentRevert)
+
+            if (revertEvents.remove(revertedEvent)) {
+                log.debug("$indent  ...Reverting $revertedEvent based on $mostRecentRevert")
+            } else {
+                if (forwardEvents.remove(revertedEvent)) {
+                    log.debug("$indent  ...Reverting $revertedEvent based on $mostRecentRevert")
+                } else {
+                    log.debug("$indent  ...There is an event that needs to be reverted but part of the last snapshot - $revertedEvent. Recursing with older snapshot...")
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private inline fun tryRunning(snapshot: Snapshot, it: Event, code: () -> EventApplyOutcome) =
+        try {
+            code()
+        } catch (e: Exception) {
+            exceptionHandler.invoke(e, snapshot, it)
+        }
+
+    private fun ((CallIdentifier, Snapshot) -> Unit).then(other: () -> Unit): (CallIdentifier, Snapshot) -> Unit = { c, s -> this(c, s); other() }
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/logging/IndentedLogging.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/logging/IndentedLogging.kt
@@ -1,0 +1,48 @@
+package com.github.rahulsom.grooves.logging
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.LoggerFactory
+import kotlin.concurrent.getOrSet
+
+@Aspect
+class IndentedLogging {
+    companion object {
+        private val indent = ThreadLocal<Int>()
+        private const val INITIAL_INDENT = 1
+        fun stepIn() = indent.set(indent.getOrSet { INITIAL_INDENT } + 1)
+        fun stepOut() = indent.set(indent.getOrSet { INITIAL_INDENT } - 1)
+        @JvmStatic
+        fun indentString() = "".padStart(indent.getOrSet { INITIAL_INDENT } * 2)
+        private fun eventsToString(it: List<*>): Any = "<... ${it.size} item(s)>"
+    }
+
+    @Suppress("unused")
+    @Around(value = "@annotation(trace)", argNames = "trace")
+    @ExperimentalStdlibApi
+    fun around(joinPoint: ProceedingJoinPoint, trace: Trace): Any? {
+        val signature = joinPoint.signature
+        val classWithFunction = joinPoint.target.javaClass
+        val loggerName = classWithFunction.name.replace(Regex("\\\$\\\$Lambda.*$"), "")
+        val log = LoggerFactory.getLogger(loggerName)
+        val methodName = if (signature.name == "invoke") signature.declaringType.simpleName.replaceFirstChar { x -> x.lowercaseChar() } else signature.name
+
+        val args = joinPoint.args.map { if (it is List<*>) eventsToString(it) else it }.joinToString(", ")
+        if (trace.twoStep) {
+            log.trace("${indentString()}$methodName($args)")
+        }
+        stepIn()
+
+        try {
+            val result = joinPoint.proceed()
+            stepOut()
+            log.trace("${indentString()}$methodName($args) --> ${if (result is List<*>) eventsToString(result) else result}")
+            return result
+        } catch (t: Throwable) {
+            stepOut()
+            log.trace("${indentString()}$methodName($args) ~~> $t")
+            throw t
+        }
+    }
+}

--- a/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/logging/Trace.kt
+++ b/grooves-core/src/main/kotlin/com/github/rahulsom/grooves/logging/Trace.kt
@@ -1,0 +1,13 @@
+package com.github.rahulsom.grooves.logging
+
+/**
+ * Marks a method as being used in tracing.
+ * These methods calls are logged at trace level with information on nesting.
+ *
+ * @see [IndentedLogging]
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Trace(
+    val twoStep: Boolean
+)

--- a/grooves-core/src/test/java/com/github/rahulsom/grooves/AcceptanceTestFixture.java
+++ b/grooves-core/src/test/java/com/github/rahulsom/grooves/AcceptanceTestFixture.java
@@ -1,0 +1,129 @@
+package com.github.rahulsom.grooves;
+
+import lombok.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AcceptanceTestFixture {
+    @AllArgsConstructor
+    @Getter
+    public static class Aggregate {
+        private int id;
+
+        @Override
+        public String toString() {
+            return MessageFormat.format("Aggregate'{'id={0}'}'", id);
+        }
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class Event {
+        private int id;
+        private int aggregateId;
+        private EventType eventType;
+
+        @NonNull
+        public EventType getEventType() {
+            return eventType;
+        }
+
+        private int version;
+        private String data;
+
+        @Override
+        public String toString() {
+            return MessageFormat.format(
+                "Event'{'id={0}, aggregateId={1}, eventType={2}, version={3}, data=''{4}'''}'",
+                id, aggregateId, eventType, version, data);
+        }
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @Setter
+    public static class Snapshot {
+        private int aggregateId;
+        private int version;
+        private String summary;
+        private List<String> deprecatedAggregates;
+
+        @Override
+        public String toString() {
+            return MessageFormat.format(
+                "Snapshot'{'aggregateId={0}, version={1}, summary=''{2}'', "
+                            + "deprecatedAggregates={3}'}'",
+                aggregateId, version, summary, deprecatedAggregates);
+        }
+    }
+
+    /**
+     * Creates a {@link GroovesQuery} with a datastore based on objects passed to it.
+     *
+     * @param objects vararg of {@link Snapshot} or {@link Event}
+     * @return The {@link GroovesQuery} to use for testing
+     */
+    @NotNull
+    public static GroovesQuery<Aggregate, Integer, Snapshot, Event, Integer> createQuery(
+            Object... objects) {
+        List<Snapshot> knownSnapshots = Arrays.stream(objects)
+                .filter(it -> it instanceof Snapshot).map(it -> (Snapshot) it)
+                .collect(Collectors.toList());
+        List<Event> events = Arrays.stream(objects)
+                .filter(it -> it instanceof Event).map(it -> (Event) it)
+                .collect(Collectors.toList());
+
+        return GroovesQueryBuilder.<Aggregate, Integer, Snapshot, Event, Integer>builder()
+            .snapshotProvider((aggregate, version) ->
+                knownSnapshots.stream()
+                    .filter(it -> it.getAggregateId() == aggregate.getId())
+                    .sorted(Comparator.comparing(Snapshot::getVersion).reversed())
+                    .filter(it -> version == null || it.getVersion() <= version)
+                    .findFirst()
+                    .orElse(null))
+            .emptySnapshotProvider(aggregate ->
+                new Snapshot(aggregate.getId(), 0, "", new ArrayList<>()))
+            .eventsProvider((aggregates, version, lastSnapshot) ->
+                events.stream()
+                    .filter(it ->
+                        aggregates.stream().anyMatch(x -> it.getAggregateId() == x.getId())
+                                && (version == null || it.getVersion() <= version)
+                                && it.getVersion() > lastSnapshot.getVersion()
+                    )
+                    .sorted(Comparator.comparing(Event::getVersion))
+            )
+            .exceptionHandler((exception, snapshot, event) -> {
+                snapshot.setSummary(snapshot.getSummary() + exception.getMessage() + ",");
+                return EventApplyOutcome.CONTINUE;
+            })
+            .eventHandler((event, snapshot) -> {
+                snapshot.setSummary(snapshot.getSummary() + event.getData() + ",");
+                return EventApplyOutcome.CONTINUE;
+            })
+            .eventClassifier(Event::getEventType)
+            .eventVersionProvider(Event::getVersion)
+            .applyMoreEventsPredicate(snapshot -> true)
+            .deprecator((snapshot, event) ->
+                snapshot.getDeprecatedAggregates().add(event.getData().split(",")[0]))
+            .snapshotVersionSetter(Snapshot::setVersion)
+            .deprecatedByProvider(event -> {
+                List<Integer> ints = Arrays.stream(event.data.split(","))
+                        .map(Integer::parseInt)
+                        .collect(Collectors.toList());
+                return new DeprecatedByResult<>(new Aggregate(ints.get(0)), ints.get(1));
+            })
+            .revertedEventProvider(event -> events.stream()
+                .filter(it -> it.getId() == Integer.parseInt(event.data))
+                .findAny()
+                .orElse(null))
+            .eventIdProvider(Event::getId)
+            .build()
+            .toQuery();
+    }
+}

--- a/grooves-core/src/test/java/com/github/rahulsom/grooves/GroovesAcceptanceTest.java
+++ b/grooves-core/src/test/java/com/github/rahulsom/grooves/GroovesAcceptanceTest.java
@@ -1,0 +1,147 @@
+package com.github.rahulsom.grooves;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static com.github.rahulsom.grooves.AcceptanceTestFixture.*;
+import static com.github.rahulsom.grooves.EventType.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GroovesAcceptanceTest {
+    @Test
+    void shouldApplyEventsIfSnapshotProviderReturnsNull() {
+        Aggregate queryAggregate = new Aggregate(1);
+
+        GroovesQuery<Aggregate, Integer, Snapshot, Event, Integer> groovesQuery =
+                createQuery(
+                    new Event(1, 1, Normal, 1, "Line 1"),
+                    new Event(2, 1, Normal, 2, "Line 2")
+                );
+
+        Snapshot snapshot1 = groovesQuery.computeSnapshot(queryAggregate, 1);
+        assertThat(snapshot1.getSummary()).isEqualTo("Line 1,");
+        assertThat(snapshot1.getVersion()).isEqualTo(1);
+
+        Snapshot snapshot2 = groovesQuery.computeSnapshot(queryAggregate, 2);
+        assertThat(snapshot2.getSummary()).isEqualTo("Line 1,Line 2,");
+        assertThat(snapshot2.getVersion()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldApplyEventsIfSnapshotProviderReturnsValue() {
+        Aggregate queryAggregate = new Aggregate(1);
+
+        GroovesQuery<Aggregate, Integer, Snapshot, Event, Integer> groovesQuery =
+                createQuery(
+                    new Snapshot(1, 2, "Line 1,Line 2,", new ArrayList<>()),
+                    new Event(3, 1, Normal, 3, "Line 3"),
+                    new Event(4, 1, Normal, 4, "Line 4")
+                );
+
+        Snapshot snapshot3 = groovesQuery.computeSnapshot(queryAggregate, 3);
+        assertThat(snapshot3.getSummary()).isEqualTo("Line 1,Line 2,Line 3,");
+        assertThat(snapshot3.getVersion()).isEqualTo(3);
+
+        Snapshot snapshot4 = groovesQuery.computeSnapshot(queryAggregate, 4);
+        assertThat(snapshot4.getSummary()).isEqualTo("Line 1,Line 2,Line 3,Line 4,");
+        assertThat(snapshot4.getVersion()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldRevertEventIfNotApplied() {
+        Aggregate queryAggregate = new Aggregate(1);
+
+        GroovesQuery<Aggregate, Integer, Snapshot, Event, Integer> groovesQuery =
+                createQuery(
+                    new Event(1, 1, Normal, 1, "Line 1"),
+                    new Event(2, 1, Normal, 2, "Line 2"),
+                    new Event(3, 1, Revert, 3, "1")
+                );
+
+        Snapshot snapshot1 = groovesQuery.computeSnapshot(queryAggregate, 1);
+        assertThat(snapshot1.getSummary()).isEqualTo("Line 1,");
+        assertThat(snapshot1.getVersion()).isEqualTo(1);
+
+        Snapshot snapshot2 = groovesQuery.computeSnapshot(queryAggregate, 2);
+        assertThat(snapshot2.getSummary()).isEqualTo("Line 1,Line 2,");
+        assertThat(snapshot2.getVersion()).isEqualTo(2);
+
+        Snapshot snapshot3 = groovesQuery.computeSnapshot(queryAggregate, 3);
+        assertThat(snapshot3.getSummary()).isEqualTo("Line 2,");
+        assertThat(snapshot3.getVersion()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldRevertRevertsEventIfNotApplied() {
+        GroovesQuery<Aggregate, Integer, Snapshot, Event, Integer> groovesQuery =
+                createQuery(
+                    new Event(1, 1, Normal, 1, "Line 1"),
+                    new Event(2, 1, Normal, 2, "Line 2"),
+                    new Event(3, 1, Revert, 3, "1"),
+                    new Event(4, 1, Normal, 4, "Line 4"),
+                    new Event(5, 1, Revert, 5, "3")
+                );
+
+        Snapshot snapshot = groovesQuery.computeSnapshot(new Aggregate(1), 5);
+        assertThat(snapshot.getSummary()).isEqualTo("Line 1,Line 2,Line 4,");
+        assertThat(snapshot.getVersion()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldRevertEventIfApplied() {
+        GroovesQuery<Aggregate, Integer, Snapshot, Event, Integer> groovesQuery =
+                createQuery(
+                    new Event(1, 1, Normal, 1, "Line 1"),
+                    new Event(2, 1, Normal, 2, "Line 2"),
+                    new Snapshot(1, 2, "Line 1,Line 2,", new ArrayList<>()),
+                    new Event(3, 1, Revert, 3, "1")
+                );
+
+        Snapshot snapshot = groovesQuery.computeSnapshot(new Aggregate(1), 3);
+        assertThat(snapshot.getSummary()).isEqualTo("Line 2,");
+        assertThat(snapshot.getVersion()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldMergeAggregatesAndReturnRedirect() {
+        GroovesQuery<Aggregate, Integer, Snapshot, Event, Integer> groovesQuery =
+                createQuery(
+                    new Event(1, 1, Normal, 1, "1.1"),
+                    new Event(2, 2, Normal, 1, "2.1"),
+                    new Event(3, 1, Normal, 2, "1.2"),
+                    new Event(4, 2, Normal, 2, "2.2"),
+                    new Event(5, 1, Deprecates, 3, "2,6"),
+                    new Event(6, 2, DeprecatedBy, 3, "1,5")
+                );
+
+        GroovesResult<Snapshot, Aggregate, Integer> result =
+                groovesQuery.computeSnapshot(new Aggregate(2), 3, false);
+        assertThat(result).isInstanceOf(GroovesResult.Redirect.class);
+        Aggregate aggregate =
+                ((GroovesResult.Redirect<Snapshot, Aggregate, Integer>) result).getAggregate();
+        Integer version = ((GroovesResult.Redirect<Snapshot, Aggregate, Integer>) result).getAt();
+
+        assertThat(aggregate.getId()).isEqualTo(1);
+        assertThat(version).isEqualTo(3);
+    }
+
+    @Test
+    void shouldMergeAggregatesAndReturnResult() {
+        GroovesQuery<Aggregate, Integer, Snapshot, Event, Integer> groovesQuery =
+                createQuery(
+                    new Event(1, 1, Normal, 1, "1.1"),
+                    new Event(2, 2, Normal, 1, "2.1"),
+                    new Event(3, 1, Normal, 2, "1.2"),
+                    new Event(4, 2, Normal, 2, "2.2"),
+                    new Event(5, 1, Deprecates, 3, "2,6"),
+                    new Event(6, 2, DeprecatedBy, 3, "1,5")
+                );
+
+        Snapshot snapshot = groovesQuery.computeSnapshot(new Aggregate(2), 3);
+        assertThat(snapshot.getAggregateId()).isEqualTo(1);
+        assertThat(snapshot.getDeprecatedAggregates()).containsExactly("2");
+        assertThat(snapshot.getSummary()).isEqualTo("1.1,2.1,1.2,2.2,");
+    }
+
+}

--- a/grooves-core/src/test/java/com/github/rahulsom/grooves/GroovesQueryBuilderTest.java
+++ b/grooves-core/src/test/java/com/github/rahulsom/grooves/GroovesQueryBuilderTest.java
@@ -1,0 +1,96 @@
+package com.github.rahulsom.grooves;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GroovesQueryBuilderTest {
+    @Test
+    @DisplayName("Should list problems if no fields are configured")
+    void shouldListProblemsIfNoFieldsAreConfigured() {
+        IllegalStateException actualException =
+                assertThrows(IllegalStateException.class,
+                        () -> GroovesQueryBuilder.builder().build().toQuery());
+
+        assertThat(actualException).isNotNull();
+        assertThat(actualException.getMessage()).isEqualTo("snapshotProvider is not set");
+        assertThat(Arrays.stream(actualException.getSuppressed()).map(Throwable::getMessage))
+                .containsExactly(
+                        "emptySnapshotProvider is not set",
+                        "eventsProvider is not set",
+                        "exceptionHandler is not set",
+                        "eventHandler is not set",
+                        "eventClassifier is not set",
+                        "applyMoreEventsPredicate is not set",
+                        "deprecator is not set",
+                        "eventVersionProvider is not set",
+                        "snapshotVersionSetter is not set",
+                        "deprecatedByProvider is not set",
+                        "revertedEventProvider is not set",
+                        "eventIdProvider is not set"
+            );
+    }
+
+    @Test
+    @DisplayName("Should list problems if some fields are configured")
+    void shouldListProblemsIfSomeFieldsAreConfigured() {
+        IllegalStateException actualException = assertThrows(IllegalStateException.class,
+                () -> GroovesQueryBuilder.builder()
+                    .emptySnapshotProvider(o -> "Hello 0")
+                    .build()
+                    .toQuery()
+        );
+
+        assertThat(actualException).isNotNull();
+        assertThat(actualException.getMessage()).isEqualTo("snapshotProvider is not set");
+        assertThat(Arrays.stream(actualException.getSuppressed()).map(Throwable::getMessage))
+                .containsExactly(
+                        "eventsProvider is not set",
+                        "exceptionHandler is not set",
+                        "eventHandler is not set",
+                        "eventClassifier is not set",
+                        "applyMoreEventsPredicate is not set",
+                        "deprecator is not set",
+                        "eventVersionProvider is not set",
+                        "snapshotVersionSetter is not set",
+                        "deprecatedByProvider is not set",
+                        "revertedEventProvider is not set",
+                        "eventIdProvider is not set"
+            );
+    }
+
+    @Test
+    @DisplayName("Should create the query if all fields are configured")
+    void shouldCreateQueryIfAllFieldsAreConfigured() {
+        GroovesQuery<UUID, Integer, List<String>, String, Integer> groovesQuery =
+                GroovesQueryBuilder
+                    .<UUID, Integer, List<String>, String, Integer>builder()
+                    .snapshotProvider((aggregate, version) -> null)
+                    .emptySnapshotProvider(aggregate -> emptyList())
+                    .eventsProvider((aggregate, version, lastSnapshot) -> Stream.empty())
+                    .exceptionHandler((exception, strings, s) -> EventApplyOutcome.CONTINUE)
+                    .eventHandler((s, strings) -> EventApplyOutcome.CONTINUE)
+                    .eventClassifier(s -> EventType.Normal)
+                    .applyMoreEventsPredicate(strings -> true)
+                    .deprecator((strings, deprecatingAggregate) -> {
+                    })
+                    .eventVersionProvider(e -> 1)
+                    .snapshotVersionSetter((s, v) -> {
+                    })
+                    .deprecatedByProvider(s -> new DeprecatedByResult<>(UUID.randomUUID(), 3))
+                    .revertedEventProvider(s -> s)
+                    .eventIdProvider(s -> 3)
+                    .build()
+                    .toQuery();
+
+        assertThat(groovesQuery).isNotNull();
+    }
+}

--- a/grooves-core/src/test/java/com/github/rahulsom/grooves/MDCExtension.java
+++ b/grooves-core/src/test/java/com/github/rahulsom/grooves/MDCExtension.java
@@ -1,0 +1,40 @@
+package com.github.rahulsom.grooves;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+public class MDCExtension implements BeforeEachCallback, AfterEachCallback {
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        LoggerFactory.getLogger(getLoggerName(context)).info(
+                "End test - {}.{}\n\n", getTestClass(context), getTestMethod(context));
+        MDC.remove("test");
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        MDC.put("test", getTestClass(context) + "." + getTestMethod(context));
+        LoggerFactory.getLogger(getLoggerName(context)).info(
+                "Begin test - {}.{}", getTestClass(context), getTestMethod(context));
+    }
+
+    private String getTestMethod(ExtensionContext context) {
+        return context.getTestMethod().get().getName();
+    }
+
+    @Nullable
+    private String getTestClass(ExtensionContext context) {
+        return context.getTestClass().map(Class::getSimpleName).orElse(null);
+    }
+
+    @NotNull
+    private String getLoggerName(ExtensionContext context) {
+        return context.getTestClass().map(Class::getName).orElse(getClass().getName());
+    }
+}

--- a/grooves-core/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/grooves-core/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+com.github.rahulsom.grooves.MDCExtension

--- a/grooves-core/src/test/resources/junit-platform.properties
+++ b/grooves-core/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+#junit.jupiter.execution.parallel.enabled = true
+#junit.jupiter.execution.parallel.mode.default = concurrent
+
+# Enable autodetection of extensions
+junit.jupiter.extensions.autodetection.enabled=true

--- a/grooves-core/src/test/resources/log4j2-test.xml
+++ b/grooves-core/src/test/resources/log4j2-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="debug">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/grooves-core/src/test/resources/logback-test.xml
+++ b/grooves-core/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %5.-5level {%X} %-36.36logger{3} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="trace">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ gradleEnterprise {
 
 rootProject.name = 'grooves'
 
-def releasable = ['api', 'groovy', 'types', 'diagrams', 'java', 'example-test']
+def releasable = ['api', 'groovy', 'types', 'diagrams', 'java', 'example-test', 'core']
 gradle.ext.releasable = releasable
 releasable.each { include "grooves-${it}" }
 


### PR DESCRIPTION
This is capable of processing a lot more events than the reactive-streams one.
It will later be used as the implementation for the older APIs