### PR TITLE
refactor: Use string interpolation prefix for kotlin

### DIFF
--- a/grooves-example-springboot-kotlin/src/main/kotlin/grooves/boot/kotlin/repositories/PatientRepository.kt
+++ b/grooves-example-springboot-kotlin/src/main/kotlin/grooves/boot/kotlin/repositories/PatientRepository.kt
@@ -24,14 +24,14 @@ interface PatientRepository : ReactiveCrudRepository<Patient, String> {
 interface PatientEventRepository : ReactiveCrudRepository<PatientEvent, String> {
     fun findAllByAggregateIdIn(aggregateIds: List<String>): Flux<PatientEvent>
 
-    @Query("{'aggregateId':?0, 'position':{'\$gt':?1, '\$lte':?2}}")
+    @Query($$"{'aggregateId':?0, 'position':{'$gt':?1, '$lte':?2}}")
     fun findAllByPositionRange(
         aggregateId: String,
         lowerBoundExclusive: Long,
         upperBoundInclusive: Long,
     ): Flux<PatientEvent>
 
-    @Query("{'aggregateId':?0, 'timestamp':{'\$gt':?1, '\$lte':?2}}")
+    @Query($$"{'aggregateId':?0, 'timestamp':{'$gt':?1, '$lte':?2}}")
     fun findAllByTimestampRange(
         aggregateId: String,
         lowerBoundExclusive: Date,


### PR DESCRIPTION
Makes expressions easier to read.
