### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
   test-site:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/rahulsom/grooves/security/code-scanning/2](https://github.com/rahulsom/grooves/security/code-scanning/2)

To resolve the issue, you should set a minimal explicit `permissions:` block for the `test-site` job in `.github/workflows/build.yml`. According to both CodeQL's recommendation and GitHub's best practices, for jobs that only need to run CI/testing and do not need to write to the repository, this should be `contents: read`. This can be done by adding the following block under `test-site:` so that it becomes sibling to `timeout-minutes:` and `runs-on:`. No changes are required to steps or other configuration lines. Only this job definition is affected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
